### PR TITLE
Fix login with two-factor authentication

### DIFF
--- a/BHTwitter/BHTwitter.xm
+++ b/BHTwitter/BHTwitter.xm
@@ -420,7 +420,15 @@
     if (![BHTManager alwaysOpenSafari]) {
         return %orig;
     }
+
     NSURL *url = [self initialURL];
+    NSString *urlStr = [url absoluteString];
+
+    // In-app browser is used for two-factor authentication with security key,
+    // login will not complete successfully if it's redirected to Safari
+    if ([urlStr hasPrefix:@"https://twitter.com/account/"]) {
+        return %orig;
+    }
 
     [[UIApplication sharedApplication] openURL:url options:@{} completionHandler:nil];
     [self dismissViewControllerAnimated:NO completion:nil];


### PR DESCRIPTION
When your account has two-factor authentication, Twitter may use an in-app browser to prompt for the code. Previously it was just a webview, but that could not be used to authenticate with security keys (WebAuthn), so they mostly use the in-app browser now. We don't want to redirect that to Safari, or else it won't log in properly inside the app.

Not tested because I don't have a Mac to build, but it should work as I've used it in NoInAppSafari.