### PR TITLE
Actually fix Safari redirect on 2FA

### DIFF
--- a/BHTwitter/BHTwitter.xm
+++ b/BHTwitter/BHTwitter.xm
@@ -422,7 +422,7 @@
 
     // In-app browser is used for two-factor authentication with security key,
     // login will not complete successfully if it's redirected to Safari
-    if ([urlStr hasPrefix:@"https://twitter.com/account/"]) {
+    if ([urlStr containsString:@"twitter.com/account/"] || [urlStr containsString:@"twitter.com/i/flow/"]) {
         return %orig;
     }
 


### PR DESCRIPTION
Looks like they changed the URL in meantime and I didn't notice, so my previous commit didn't fix it properly.