### PR TITLE
Add Show Scroll Bar

### DIFF
--- a/BHTwitter/BHTManager.h
+++ b/BHTwitter/BHTManager.h
@@ -41,6 +41,7 @@
 + (BOOL)DmModularSearch;
 + (BOOL)disableSensitiveTweetWarnings;
 + (BOOL)TwitterCircle;
++ (BOOL)showScrollIndicator;
 + (BOOL)CopyProfileInfo;
 + (BOOL)tweetToImage;
 + (BOOL)hideSpacesBar;

--- a/BHTwitter/BHTManager.m
+++ b/BHTwitter/BHTManager.m
@@ -165,6 +165,9 @@
 + (BOOL)TwitterCircle {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"TrustedFriends"];
 }
++ (BOOL)showScrollIndicator {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"showScollIndicator"];
+}
 + (BOOL)CopyProfileInfo {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"CopyProfileInfo"];
 }

--- a/BHTwitter/BHTwitter.x
+++ b/BHTwitter/BHTwitter.x
@@ -1121,24 +1121,33 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
 }
 %end
 
+// MARK: Show Scroll Bar
+%hook TFNTableView
+- (void)setShowsVerticalScrollIndicator:(BOOL)arg1 {
+    %orig([BHTManager showScrollIndicator]);
+}
+%end
+
 // MARK: Fix login keychain in non-JB (IPA).
-//%hook TFSKeychain
-//- (NSString *)providerDefaultAccessGroup {
-//    return accessGroupID();
-//}
-//- (NSString *)providerSharedAccessGroup {
-//    return accessGroupID();
-//}
-//%end
-//
-//%hook TFSKeychainDefaultTwitterConfiguration
-//- (NSString *)defaultAccessGroup {
-//    return accessGroupID();
-//}
-//- (NSString *)sharedAccessGroup {
-//    return accessGroupID();
-//}
-//%end
+#if 0
+%hook TFSKeychain
+- (NSString *)providerDefaultAccessGroup {
+    return accessGroupID();
+}
+- (NSString *)providerSharedAccessGroup {
+    return accessGroupID();
+}
+%end
+
+%hook TFSKeychainDefaultTwitterConfiguration
+- (NSString *)defaultAccessGroup {
+    return accessGroupID();
+}
+- (NSString *)sharedAccessGroup {
+    return accessGroupID();
+}
+%end
+#endif
 
 // MARK: Clean tracking from copied links: https://github.com/BandarHL/BHTwitter/issues/75
 %ctor {

--- a/BHTwitter/Package/Library/Application Support/BHT/BHTwitter.bundle/en.lproj/Localizable.strings
+++ b/BHTwitter/Package/Library/Application Support/BHT/BHTwitter.bundle/en.lproj/Localizable.strings
@@ -84,6 +84,8 @@
 "DISABLE_SENSITIVE_TWEET_WARNINGS_OPTION_TITLE" = "Disable sensitive tweet warning view";
 "TRUSTED_FRIENSS_OPTION_TITLE" = "Enable Twitter Circle feature";
 
+"SHOW_SCOLL_INDICATOR_OPTION_TITLE" = "Show Scroll Bar";
+
 "COPY_PROFILE_INFO_OPTION_TITLE" = "Enable Copying profile information feature";
 "COPY_PROFILE_INFO_OPTION_DETAIL_TITLE" = "Add new button in Twitter profile that let you copy whatever info you want.";
 

--- a/BHTwitter/SettingsViewController.m
+++ b/BHTwitter/SettingsViewController.m
@@ -173,6 +173,8 @@
         PSSpecifier *disableSensitiveTweetWarnings = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"DISABLE_SENSITIVE_TWEET_WARNINGS_OPTION_TITLE"] detailTitle:nil key:@"disableSensitiveTweetWarnings" defaultValue:true changeAction:nil];
         
         PSSpecifier *trustedFriends = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"TRUSTED_FRIENSS_OPTION_TITLE"] detailTitle:nil key:@"TrustedFriends" defaultValue:true changeAction:nil];
+
+        PSSpecifier *showScrollIndicator = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"SHOW_SCOLL_INDICATOR_OPTION_TITLE"] detailTitle:nil key:@"showScollIndicator" defaultValue:true changeAction:nil];
         
         PSSpecifier *copyProfileInfo = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"COPY_PROFILE_INFO_OPTION_TITLE"] detailTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"COPY_PROFILE_INFO_OPTION_DETAIL_TITLE"] key:@"CopyProfileInfo" defaultValue:false changeAction:nil];
         
@@ -250,6 +252,7 @@
             alwaysOpenSafari,
             stripTrackingParams,
             trustedFriends,
+            showScrollIndicator,
             
             twitterBlueSection, // 1
             undoTweet,

--- a/BHTwitter/TWHeaders.h
+++ b/BHTwitter/TWHeaders.h
@@ -46,7 +46,8 @@ static NSString *_lastCopiedURL;
 @property (nonatomic, strong) id scribe;
 @end
 
-@interface TFNTableView: UITableView
+@interface TFNTableView : UITableView
+- (void)setShowsVerticalScrollIndicator:(BOOL)arg1;
 @end
 
 @interface TFNDataViewController : UIViewController


### PR DESCRIPTION
This allows the user to set if the vertical scroll bar is visible. Changes seem to take affect on timeline refreshes, and force quitting the app. This should also address #119.

Lastly, I wrapped the "Fix login keychain in non-JB (IPA)" hooks in a preprocessor block to make it easier to enable and disable it.