### PR TITLE
Fix crash due to unexpected fonts methods.

### DIFF
--- a/BHTwitter/BHTwitter.x
+++ b/BHTwitter/BHTwitter.x
@@ -1102,11 +1102,13 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
         Method *methods = class_copyMethodList([self class], &methodCount);
         for (unsigned int i = 0; i < methodCount; ++i) {
             Method method = methods[i];
+            char returnType[255];
+            method_getReturnType(method, returnType, 255);
             const char *name = sel_getName(method_getName(method));
             NSString *selector = [NSString stringWithUTF8String:name];
 
-            // Don't add methods with arguments
-            if (![selector containsString:@":"]) {
+            // Just add methods that have return type.
+            if ([@(returnType) containsString:@"@"]) {
                 [fontsMethods addObject:selector];
             }
         }

--- a/BHTwitter/BHTwitter.x
+++ b/BHTwitter/BHTwitter.x
@@ -1104,7 +1104,11 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
             Method method = methods[i];
             const char *name = sel_getName(method_getName(method));
             NSString *selector = [NSString stringWithUTF8String:name];
-            [fontsMethods addObject:selector];
+
+            // Don't add methods with arguments
+            if (![selector containsString:@":"]) {
+                [fontsMethods addObject:selector];
+            }
         }
         free(methods);
         


### PR DESCRIPTION
In twitter 9.47 there are some methods in `TAEStandardFontGroup` that have arguments,
```
fontOfSize:
mediumFontOfSize:
boldFontOfSize:
heavyFontOfSize:
monospacedDigitFontOfSize:weight:
```
The method that these are replaced with don't seem to handle them, so I added a small check to filter these methods out. This has also fixed the crash in #129 for me.

Also, I'm assuming the target methods are like,
```
- (id)subtext1MediumFont;
- (id)subtext1BoldFont;
- (id)bodyFont;
```
and don't include methods like,
```
- (void)_tae_resetFont_subtext3Font;
- (void)_tae_resetFont_subtext3MediumFont;
- (void)_tae_resetFont_subtext3BoldFont;
- (void)_tae_resetFont_subtext2Font;
```
If so, I believe a better method would be to filter by method type encodings. We would be looking for methods with the following type encoding, `@@:`. Please let me know if I should use that instead.