### PR TITLE
add vxtwitter copy option

### DIFF
--- a/BHTwitter/BHTManager.h
+++ b/BHTwitter/BHTManager.h
@@ -49,6 +49,7 @@
 + (BOOL)hideViewCount;
 + (BOOL)forceTweetFullFrame;
 + (BOOL)stripTrackingParams;
++ (BOOL)copyAsVxTwitter;
 + (BOOL)disableImmersive;
 + (BOOL)alwaysFollowingPage;
 + (BOOL)stopHidingTabBar;

--- a/BHTwitter/BHTManager.m
+++ b/BHTwitter/BHTManager.m
@@ -189,6 +189,9 @@
 + (BOOL)stripTrackingParams {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"strip_tracking_params"];
 }
++ (BOOL)copyAsVxTwitter {
+    return [[NSUserDefaults standardUserDefaults] boolForKey:@"copy_as_vxtwitter"];
+}
 + (BOOL)disableImmersive {
     return [[NSUserDefaults standardUserDefaults] boolForKey:@"disable_immersive_player"];
 }

--- a/BHTwitter/BHTwitter.x
+++ b/BHTwitter/BHTwitter.x
@@ -1217,27 +1217,34 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
             };
         });
         
-        if ([BHTManager stripTrackingParams]) {
-            if (UIPasteboard.generalPasteboard.hasURLs) {
-                NSURL *pasteboardURL = UIPasteboard.generalPasteboard.URL;
-                NSArray<NSString*>* params = trackingParams[pasteboardURL.host];
-                
-                if ([pasteboardURL.absoluteString isEqualToString:_lastCopiedURL] == NO && params != nil && pasteboardURL.query != nil) {
-                    // to prevent endless copy loop
-                    _lastCopiedURL = pasteboardURL.absoluteString;
-                    NSURLComponents *cleanedURL = [NSURLComponents componentsWithURL:pasteboardURL resolvingAgainstBaseURL:NO];
-                    NSMutableArray<NSURLQueryItem*> *safeParams = [NSMutableArray arrayWithCapacity:0];
-                    
-                    for (NSURLQueryItem *item in cleanedURL.queryItems) {
-                        if ([params containsObject:item.name] == NO) {
-                            [safeParams addObject:item];
-                        }
-                    }
-                    cleanedURL.queryItems = safeParams;
-                    UIPasteboard.generalPasteboard.URL = cleanedURL.URL;
+if ([BHTManager stripTrackingParams]) {
+    if (UIPasteboard.generalPasteboard.hasURLs) {
+        NSURL *pasteboardURL = UIPasteboard.generalPasteboard.URL;
+        NSArray<NSString*>* params = trackingParams[pasteboardURL.host];
+        
+        if ([pasteboardURL.absoluteString isEqualToString:_lastCopiedURL] == NO && params != nil && pasteboardURL.query != nil) {
+            // to prevent endless copy loop
+            _lastCopiedURL = pasteboardURL.absoluteString;
+            NSURLComponents *cleanedURL = [NSURLComponents componentsWithURL:pasteboardURL resolvingAgainstBaseURL:NO];
+            NSMutableArray<NSURLQueryItem*> *safeParams = [NSMutableArray arrayWithCapacity:0];
+            
+            for (NSURLQueryItem *item in cleanedURL.queryItems) {
+                if ([params containsObject:item.name] == NO) {
+                    [safeParams addObject:item];
                 }
             }
+            cleanedURL.queryItems = safeParams;
+
+            if ([BHTManager copyAsVxTwitter]) {
+                if ([cleanedURL.host isEqualToString:@"twitter.com"] || [cleanedURL.host isEqualToString:@"x.com"]) {
+                    cleanedURL.host = @"vxtwitter.com";
+                }
+            }
+
+            UIPasteboard.generalPasteboard.URL = cleanedURL.URL;
         }
+    }
+}
     }];
     %init;
 }

--- a/BHTwitter/Package/Library/Application Support/BHT/BHTwitter.bundle/en.lproj/Localizable.strings
+++ b/BHTwitter/Package/Library/Application Support/BHT/BHTwitter.bundle/en.lproj/Localizable.strings
@@ -101,6 +101,9 @@
 "STRIP_URL_TRACKING_PARAMETERS_TITLE" = "Remove tracking from URL's";
 "STRIP_URL_TRACKING_PARAMETERS_DETAIL_TITLE" = "Strip tracking parameters from tweet URL's when it's copy";
 
+"COPY_URL_AS_VXTWITTER_OPTION_TITLE" = "Copy URL as VXtwitter";
+"COPY_URL_AS_VXTWITTER_OPTION_DETAIL_TITLE" = "Copy URL as VXtwitter instead of Twitter.com/X.com.\nThis is useful, since Twitter/X disables link previews every other day.";
+
 "TWITTER_BLUE_SECTION_HEADER_TITLE" = "Twitter blue features";
 "UNDO_TWEET_OPTION_TITLE" = "Undo tweets feature";
 "UNDO_TWEET_OPTION_DETAIL_TITLE" = "Undo tweets after tweeting.";

--- a/BHTwitter/SettingsViewController.m
+++ b/BHTwitter/SettingsViewController.m
@@ -182,6 +182,8 @@
         PSSpecifier *alwaysOpenSafari = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"ALWAYS_OPEN_SAFARI_OPTION_TITLE"] detailTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"ALWAYS_OPEN_SAFARI_OPTION_DETAIL_TITLE"] key:@"openInBrowser" defaultValue:false changeAction:nil];
         
         PSSpecifier *stripTrackingParams = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"STRIP_URL_TRACKING_PARAMETERS_TITLE"] detailTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"STRIP_URL_TRACKING_PARAMETERS_DETAIL_TITLE"] key:@"strip_tracking_params" defaultValue:false changeAction:nil];
+
+        PSSpecifier *copyAsVxTwitter = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"COPY_URL_AS_VXTWITTER_OPTION_TITLE"] detailTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"COPY_URL_AS_VXTWITTER_OPTION_DETAIL_TITLE"] key:@"copy_as_vxtwitter" defaultValue:false changeAction:nil];
         
         PSSpecifier *advancedSearch = [self newSwitchCellWithTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"ADVANCED_SEARCH_TITLE"] detailTitle:[[BHTBundle sharedBundle] localizedStringForKey:@"ADVANCED_SEARCH_DETAIL_TITLE"] key:@"advanced_search" defaultValue:false changeAction:nil];
 
@@ -250,6 +252,7 @@
             disableRTL,
             alwaysOpenSafari,
             stripTrackingParams,
+            copyAsVxTwitter,
             trustedFriends,
             advancedSearch,
             


### PR DESCRIPTION
Hey Bandar, 

This might not be a fully working solution as I'm having Sonoma issues and can't build it, but in theory, this would add support to vxtwitter copy instead of the regular twitter/x copy. This can be useful, since every other day Twitter decides to disable link previews, which is kinda annoying, as I know my friends would just rather see the post than click on it. 

VXTwitter comes from: https://github.com/dylanpdx/BetterTwitFix

Thanks!
-8x4