### PR TITLE
Fix unneeded `?` appended when query params is empty

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -1302,7 +1302,7 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
                             [safeParams addObject:item];
                         }
                     }
-                    cleanedURL.queryItems = safeParams;
+                    cleanedURL.queryItems = safeParams.count > 0 ? safeParams : nil;
 
                     if ([[NSUserDefaults standardUserDefaults] objectForKey:@"tweet_url_host"]) {
                         NSString *selectedHost = [[NSUserDefaults standardUserDefaults] objectForKey:@"tweet_url_host"];


### PR DESCRIPTION
## Fixed

- Currently, if "Remove tracking from URLs" option is enabled and all query parameters are removed, unneeded `?` is appended to the copied URL.
  - e.g. `https://x.com/haxibami/0000000000000?`
  - It seems to be caused by assigning empty array to `NSURLComponents.queryItems`.

## Check

- X / Twitter IPA `10.59.1`
- Sideloaded by SideStore