### PR TITLE
Hide the "Upgrade" button on the latest (version 10.60) client

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -866,6 +866,12 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
     }
     return %orig;
 }
+- (void)_t1_showPremiumUpsellIfNeededWithScribing:(BOOL)arg1 {
+    if ([BHTManager hidePremiumOffer]) {
+        return;
+    }
+    return %orig;
+}
 %end
 
 %hook TFNTwitterMediaUploadConfiguration


### PR DESCRIPTION
## Fixed

- If built with the latest (version 10.60) IPA file, the "Upgrade" button is not hidden by that option.
  - Looks like method name was changed in version 10.60

## Check

- IPA version `10.60`
- Sideloaded by SideStore