### PR TITLE
chore: azule -> cyan for injection

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -77,18 +77,9 @@ jobs:
           path: theos
           submodules: recursive
 
-      - name: Download Azule
+      - name: Install cyan
         if: inputs.deploy_format == 'sideloaded' || inputs.deploy_format == 'trollstore'
-        uses: actions/checkout@v4
-        with:
-          repository: Al4ise/Azule
-          ref: main
-          path: azule
-
-      - name: Add Azule to PATH
-        if: inputs.deploy_format == 'sideloaded' || inputs.deploy_format == 'trollstore'
-        run: |
-          echo "${{ github.workspace }}/azule" >> "$GITHUB_PATH"
+        run: pip install https://github.com/asdfzxcvbn/pyzule-rw/archive/main.zip
 
       - name: iOS SDK Caching
         id: SDK

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@
 ## Local
 
 - install [Theos](https://github.com/theos/theos)
-- install [Azule](https://github.com/Al4ise/Azule) if you want to build for sideload or TrollStore
+- install [cyan](https://github.com/asdfzxcvbn/pyzule-rw) if you want to build for sideload or TrollStore
 
 - Clone the BHTwitter project repository:
 ```bash

--- a/build.sh
+++ b/build.sh
@@ -2,8 +2,6 @@
 
 LONG=sideloaded:,rootless:,trollstore
 OPTS=$(getopt -a weather --longoptions "$LONG" -- "$@")
-libcephei_URL="https://web.archive.org/web/20240222081324/https://cdn.discordapp.com/attachments/755439561454256132/1184388888475738243/libcephei.zip"
-PROJECT_PATH=$PWD
 
 while :; do
   case "$1" in
@@ -22,16 +20,10 @@ while :; do
       fi
 
       if [ -e ./packages/com.atebits.Tweetie2.ipa ]; then
-
-        echo -e '\033[1m\033[32mDownloading libcephei SDK.\033[0m'
-        temp_dir=$(mktemp -d)
-        curl -L -o "$temp_dir/libcephei.zip" "$libcephei_URL"
-        unzip -o "$temp_dir/libcephei.zip" -d ./packages
-        rm -rf "$temp_dir"
-        rm -rf ./packages/__MACOSX
-
         echo -e '\033[1m\033[32mBuilding the IPA.\033[0m'
-        azule -i "$PROJECT_PATH/packages/com.atebits.Tweetie2.ipa" -o "$PROJECT_PATH/packages" -n BHTwitter-sideloaded -r -f "$PROJECT_PATH/.theos/obj/debug/keychainfix.dylib" "$PROJECT_PATH/.theos/obj/debug/libbhFLEX.dylib" "$PROJECT_PATH/.theos/obj/debug/BHTwitter.dylib" "$PROJECT_PATH/packages/Cephei.framework" "$PROJECT_PATH/packages/CepheiUI.framework" "$PROJECT_PATH/packages/CepheiPrefs.framework" "$PROJECT_PATH/layout/Library/Application Support/BHT/BHTwitter.bundle"
+        cyan -i packages/com.atebits.Tweetie2.ipa -o packages/BHTwitter-sideloaded --ignore-encrypted \
+          -uwf .theos/obj/debug/keychainfix.dylib .theos/obj/debug/libbhFLEX.dylib \
+          .theos/obj/debug/BHTwitter.dylib layout/Library/Application\ Support/BHT/BHTwitter.bundle
 
         echo -e '\033[1m\033[32mDone, thanks for using BHTwitter.\033[0m'
       else
@@ -65,18 +57,10 @@ while :; do
       fi
 
       if [ -e ./packages/com.atebits.Tweetie2.ipa ]; then
-
-        echo -e '\033[1m\033[32mDownloading libcephei SDK.\033[0m'
-        temp_dir=$(mktemp -d)
-        curl -L -o "$temp_dir/libcephei.zip" "$libcephei_URL"
-        unzip -o "$temp_dir/libcephei.zip" -d ./packages
-        rm -rf "$temp_dir"
-        rm -rf ./packages/__MACOSX
-
         echo -e '\033[1m\033[32mBuilding the IPA.\033[0m'
 
-        azule -i "$PROJECT_PATH/packages/com.atebits.Tweetie2.ipa" -o "$PROJECT_PATH/packages" -n BHTwitter-trollstore -r -f "$PROJECT_PATH/.theos/obj/debug/BHTwitter.dylib" "$PROJECT_PATH/.theos/obj/debug/libbhFLEX.dylib" "$PROJECT_PATH/packages/Cephei.framework" "$PROJECT_PATH/packages/CepheiUI.framework" "$PROJECT_PATH/packages/CepheiPrefs.framework" "$PROJECT_PATH/layout/Library/Application Support/BHT/BHTwitter.bundle"
-        mv "$PROJECT_PATH/packages/BHTwitter-trollstore.ipa" "$PROJECT_PATH/packages/BHTwitter-trollstore.tipa"
+        cyan -i packages/com.atebits.Tweetie2.ipa -o packages/BHTwitter-trollstore.tipa --ignore-encrypted \
+          -uwf .theos/obj/debug/BHTwitter.dylib .theos/obj/debug/libbhFLEX.dylib layout/Library/Application\ Support/BHT/BHTwitter.bundle
 
         echo -e '\033[1m\033[32mDone, thanks for using BHTwitter.\033[0m'
       else


### PR DESCRIPTION
[cyan](https://github.com/asdfzxcvbn/pyzule-rw) is my own injector inspired by azule (you can read more info on its "old page": https://github.com/asdfzxcvbn/pyzule)

cyan has some niceties over azule, including:
- no pathfinding issues, no more `$pwd/packages/...`
- installable with a single command on github actions (no adding to PATH)
- no need to manually download cephei, cyan will fix that dependency for you automatically!
- actively maintained

i already tested both the sideloaded and trollstore actions and they work great. i also updated the README. cyan isn't a small project: its predecessor, pyzule, was used in quite a lot of places. cyan is now also used in the [YTLite workflow](https://github.com/dayanch96/YTLite/blob/fc8e5daf7bdc2b11c36ad3ac02cc83b6064e4f94/.github/workflows/ytp_tweaks.yml#L148)

let me know if you have any questions :)