### PR TITLE
Feature: hide timeline messages

### DIFF
--- a/Tweak.x
+++ b/Tweak.x
@@ -384,6 +384,12 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
                 return 0;
             }
         }
+
+        if ([BHTManager hidePremiumOffer]) {
+            if ([class_name isEqualToString:@"T1URTTimelineMessageItemViewModel"]) {
+                return 0;
+            }
+        }
     }
     
     return %orig;

--- a/Tweak.x
+++ b/Tweak.x
@@ -324,6 +324,12 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
                 [_orig setHidden:true];
             }
         }
+
+        if ([BHTManager hidePremiumOffer]) {
+            if ([class_name isEqualToString:@"T1URTTimelineMessageItemViewModel"]) {
+                return 0;
+            }
+        }
     }
     
     return _orig;

--- a/Tweak.x
+++ b/Tweak.x
@@ -327,7 +327,7 @@ static void batchSwizzlingOnClass(Class cls, NSArray<NSString*>*origSelectors, I
 
         if ([BHTManager hidePremiumOffer]) {
             if ([class_name isEqualToString:@"T1URTTimelineMessageItemViewModel"]) {
-                return 0;
+                [_orig setHidden:true];
             }
         }
     }


### PR DESCRIPTION
## Overview

- The option to hide premium offer now also hides offers (messages) displayed on timeline.

<details><summary>sample offer</summary>

![premium_message](https://github.com/user-attachments/assets/85deeb69-3809-411a-97dd-45d286c3bb03)

</details>

## Check

- sideloaded by SideStore
- X / Twitter IPA version: `10.62`