### PR TITLE
use `CoreServices.h` instead of `MobileCoreServices.h` to suppress `kUTTypeMovie` build error

### DIFF
--- a/TWHeaders.h
+++ b/TWHeaders.h
@@ -8,7 +8,7 @@
 #import <objc/runtime.h>
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import <MobileCoreServices/MobileCoreServices.h>
+#import <CoreServices/CoreServices.h>
 #import <AVKit/AVKit.h>
 #import <Photos/Photos.h>
 #import <SafariServices/SafariServices.h>


### PR DESCRIPTION
## Change

- Fixed a compilation error with the latest theos headers [update](https://github.com/theos/headers/commit/14358448fe223a4af0d1cc5f50fcb1fd969f9c8b).

```log
==> Compiling ThemeColor/BHColorThemeViewController.m (arm64)…
Tweak.x:554:43: error: use of undeclared identifier 'kUTTypeMovie'
==> Compiling Tweak.x (arm64)…
    videoPicker.mediaTypes = @[(NSString*)kUTTypeMovie];
rm /Users/runner/work/BHTwitter/BHTwitter/main/.theos/obj/debug/arm64/Tweak.x.m
                                          ^
Make command failed.
```

## Check

- X / Twitter IPA: `10.65.2`
- Sideloaded by SideStore